### PR TITLE
Add authentication system (register, login, JWT)

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,78 @@
+import os
+from datetime import datetime, timedelta, timezone
+from jose import jwt, JWTError
+from passlib.context import CryptContext
+
+JWT_SECRET = os.getenv("JWT_SECRET", "CHANGE_ME")
+
+# algorithm used for JWT  --> JSON Web Token 
+# simple, fast and most commen alg for API. we could change it latter if we wanted
+ALGORITHM = "HS256"
+
+# token expiration time (in minutes) -- 1h
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+# pbkdf2_sha256 --> key derivation function designed to produce a symmtric cryptographic key from a password
+pwd_context = CryptContext(
+    schemes=["pbkdf2_sha256"],
+    deprecated="auto"
+)
+
+
+def hash_password(password: str) -> str:
+    """
+    hashs a plaintext password before storing it in the database.
+    never store plain passwords
+    """
+    return pwd_context.hash(password)
+
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """
+    compares a plaintext password with a stored hashed password.
+    returns true if passwords match.
+    """
+    return pwd_context.verify(password, hashed_password)
+
+
+
+def create_access_token(subject: str) -> str:
+    """
+    This function creates a JWT token after the user logs in successfully.
+
+    The "subject" is basically who the token belongs to.
+    In our case, we use the user's email to identify them.
+
+    Inside the token we store:
+        - "sub": the user's identity
+        - "exp": the expiration time (so the token doesn't last forever)
+
+    The token is signed using our secret key and HS256 algorithm,
+    which means if someone tries to change anything inside the token,
+    the signature will not match and the request will be rejected.
+
+    We use this token instead of sessions, so the user sends it
+    with every request to prove they are authenticated.
+    """
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    payload = {"sub": subject, "exp": expire}
+    return jwt.encode(payload, JWT_SECRET, algorithm=ALGORITHM)
+
+
+
+def decode_access_token(token: str) -> str:
+    """    
+    Decode the token using the same secret and algorithm.
+    This step verifies:
+       1) The signature is valid (token wasn't changed)
+       2) The token has not expired 
+    """
+    payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+    sub = payload.get("sub")
+    # If the token does not contain a subject,
+    # we raise an error
+    if not sub:
+        raise JWTError("Missing sub")
+    # return the user's id (email)
+    return sub

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,23 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./envmonitor.db")
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+# connection to the database
+engine = create_engine(DATABASE_URL, connect_args=connect_args, pool_pre_ping=True)
+
+
+# create a session
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+class Base(DeclarativeBase):
+    pass
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from dotenv import load_dotenv
+
+from app.database import Base, engine
+from app.routers.auth import router as auth_router
+
+load_dotenv()
+
+app = FastAPI(title="Flight Booking API")
+
+
+Base.metadata.create_all(bind=engine)
+
+# routers
+app.include_router(auth_router)
+
+@app.get("/")
+def root():
+    return {"message": "API is running"}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,3 @@
+# Importing the model ensures it is loaded into sqlalchemy metadata.
+# so without it base.metadata.create_all() will not create the users table.
+from .user import User  # noqa: F401

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+from app.database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    # primary key column
+    # every user will have a unique id (auto-incremented).
+    id: Mapped[int] = mapped_column(primary_key=True)
+    # max 255
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    # this stores the hashed password
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -1,0 +1,17 @@
+from sqlalchemy.orm import Session
+from app.models.user import User
+
+def get_user_by_email(db: Session, email: str) -> User | None:
+    """
+    search the database for a given email, returns none if 
+    user does not exist
+    """
+    return db.query(User).filter(User.email == email).first()
+
+# this function creates a new user in the database.
+def create_user(db: Session, email: str, hashed_password: str) -> User:
+    user = User(email=email, hashed_password=hashed_password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,105 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.schemas.auth import RegisterRequest, LoginRequest, TokenResponse, MeResponse
+from app.services.auth_service import register, login, AuthError
+from app.core.security import decode_access_token
+from app.repositories.user_repository import get_user_by_email
+
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+
+@router.post("/register", response_model=MeResponse, status_code=201)
+def register_endpoint(body: RegisterRequest, db: Session = Depends(get_db)):
+    """
+    endpoint to register a new user.
+
+    it takes the email and password from the request,
+    creates the user, and returns basic user info --> id email for now 
+    but we could add stuff later first, last name, data of birth etc
+    """
+    # register a new user.
+    try:
+        user = register(db, body.email, body.password)
+        return MeResponse(id=user.id, email=user.email)
+    except AuthError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+
+@router.post("/login", response_model=TokenResponse)
+def login_endpoint(body: LoginRequest, db: Session = Depends(get_db)):
+    """
+    Login endpoint:
+    - Checks email/password
+    - If correct, returns a JWT token
+    """
+    try:
+        token = login(db, body.email, body.password)
+        return TokenResponse(access_token=token)
+    except AuthError as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
+
+
+
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)):
+    """
+    This function checks if the user is authenticated.
+
+    It takes the JWT token from the request, verifies it,
+    and gets the user's email from it.
+
+    If the token is invalid, expired, or the user doesn't exist,
+    it returns a 401 error.
+
+    If everything is valid, it returns the user.
+    """
+    # decode the token to get the user's email
+    try:
+        email = decode_access_token(token)
+    # If decoding fails and token is invalid or expired
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    # look for the user in the database
+    user = get_user_by_email(db, email)
+    # if no user, deny access
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    # everything is valid
+    return user
+
+
+@router.post("/token", response_model=TokenResponse)
+def token_endpoint(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db)
+):
+    """
+    This endpoint is mainly for Swagger's Authorize button.
+
+    Swagger sends login info as form-data:
+    - username (we use it as email)
+    - password
+    """
+    try:
+        token = login(db, form_data.username, form_data.password)
+        return TokenResponse(access_token=token)
+    except AuthError as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
+    
+
+@router.get("/me", response_model=MeResponse)
+def me_endpoint(user=Depends(get_current_user)):
+    """
+    A protected route:
+    if the token is valid, it returns the user's info
+    else returns 401
+    """
+    return MeResponse(id=user.id, email=user.email)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,47 @@
+import re
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+import re
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, value: str) -> str:
+        """
+        Password must contain:
+        - At least one uppercase letter
+        - At least one lowercase letter
+        - At least one number
+        - At least one special character
+        """
+
+        if not re.search(r"[A-Z]", value):
+            raise ValueError("Password must contain at least one uppercase letter")
+
+        if not re.search(r"[a-z]", value):
+            raise ValueError("Password must contain at least one lowercase letter")
+
+        if not re.search(r"[0-9]", value):
+            raise ValueError("Password must contain at least one number")
+
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", value):
+            raise ValueError("Password must contain at least one special character")
+
+        return value
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=1, max_length=128)
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class MeResponse(BaseModel):
+    id: int
+    email: EmailStr

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+from app.core.security import hash_password, verify_password, create_access_token
+from app.repositories.user_repository import get_user_by_email, create_user
+
+class AuthError(Exception):
+    pass
+
+def register(db: Session, email: str, password: str):
+    """
+    register a new user.
+    - check if the email already exists
+    - hash the password
+    - save user in the database
+    """
+    # if a user already exists with this email, block registration
+    if get_user_by_email(db, email):
+        raise AuthError("Email already registered")
+    return create_user(db, email, hash_password(password))
+
+def login(db: Session, email: str, password: str) -> str:
+    """
+    log in a user.
+    - find the user by email
+    - verify the password matches the stored hash
+    - if valid, return a JWT token
+    """
+    user = get_user_by_email(db, email)
+    if not user or not verify_password(password, user.hashed_password):
+        raise AuthError("Invalid email or password")
+    return create_access_token(subject=user.email)


### PR DESCRIPTION
Implemented a basic authentication system for the project.

- users can register using email and password
- passwords are securely hashed before storing in the database
- users can log in and receive a JWT token
- added a protected /auth/me route to test authentication

now registration only requires email and password, but we can add more fields later (like first name, last name, phone, date of birth, passsport)

If we have time later, we could also add a password reset feature using email.