### PR TITLE
Add structured tests for register, login, and JWT authentication

### DIFF
--- a/backend/tests/auth/test_login.py
+++ b/backend/tests/auth/test_login.py
@@ -1,0 +1,54 @@
+def _register_user(client, email="login@example.com", password="Password1!"):
+    return client.post("/auth/register", json={"email": email, "password": password})
+
+
+def test_login_success_returns_token(client):
+    _register_user(client, email="login-ok@example.com")
+
+    r = client.post(
+        "/auth/login",
+        json={"email": "login-ok@example.com", "password": "Password1!"},
+    )
+    assert r.status_code == 200
+
+    data = r.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+    assert isinstance(data["access_token"], str)
+    assert data["access_token"].count(".") == 2
+
+
+def test_login_wrong_password_401(client):
+    _register_user(client, email="wrongpass@example.com")
+
+    r = client.post(
+        "/auth/login",
+        json={"email": "wrongpass@example.com", "password": "WrongPass1!"},
+    )
+    assert r.status_code == 401
+    assert "detail" in r.json()
+    assert "invalid" in r.json()["detail"].lower()
+
+
+def test_login_user_not_found_401(client):
+    r = client.post(
+        "/auth/login",
+        json={"email": "missing@example.com", "password": "Password1!"},
+    )
+    assert r.status_code == 401
+    assert "detail" in r.json()
+
+
+def test_login_missing_fields_422(client):
+    r = client.post("/auth/login", json={})
+    assert r.status_code == 422
+
+
+def test_login_invalid_email_format_422(client):
+    r = client.post("/auth/login", json={"email": "bad-email", "password": "Password1!"})
+    assert r.status_code == 422
+
+
+def test_login_empty_password_422(client):
+    r = client.post("/auth/login", json={"email": "x@example.com", "password": ""})
+    assert r.status_code == 422

--- a/backend/tests/auth/test_me.py
+++ b/backend/tests/auth/test_me.py
@@ -1,0 +1,27 @@
+def _register_and_login(client, email="me@example.com", password="Password1!"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_me_requires_token_401(client):
+    r = client.get("/auth/me")
+    assert r.status_code == 401
+
+
+def test_me_rejects_invalid_token_401(client):
+    r = client.get("/auth/me", headers={"Authorization": "Bearer not-a-real-token"})
+    assert r.status_code == 401
+    assert "detail" in r.json()
+
+
+def test_me_success_returns_user(client):
+    token = _register_and_login(client, email="me-ok@example.com")
+
+    r = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+
+    data = r.json()
+    assert "id" in data
+    assert data["email"] == "me-ok@example.com"

--- a/backend/tests/auth/test_register.py
+++ b/backend/tests/auth/test_register.py
@@ -1,0 +1,64 @@
+def test_register_success(client):
+    r = client.post(
+        "/auth/register",
+        json={"email": "user@example.com", "password": "Password1!"},
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert "id" in data
+    assert data["email"] == "user@example.com"
+
+
+def test_register_duplicate_email_returns_400(client):
+    client.post(
+        "/auth/register",
+        json={"email": "dup@example.com", "password": "Password1!"},
+    )
+
+    r = client.post(
+        "/auth/register",
+        json={"email": "dup@example.com", "password": "Password1!"},
+    )
+    assert r.status_code == 400
+    assert "detail" in r.json()
+    assert "already" in r.json()["detail"].lower()
+
+
+def test_register_missing_email_422(client):
+    r = client.post("/auth/register", json={"password": "Password1!"})
+    assert r.status_code == 422
+
+
+def test_register_missing_password_422(client):
+    r = client.post("/auth/register", json={"email": "x@example.com"})
+    assert r.status_code == 422
+
+
+def test_register_invalid_email_format_422(client):
+    r = client.post("/auth/register", json={"email": "not-an-email", "password": "Password1!"})
+    assert r.status_code == 422
+
+
+def test_register_password_too_short_422(client):
+    r = client.post("/auth/register", json={"email": "short@example.com", "password": "P1!a"})
+    assert r.status_code == 422
+
+
+def test_register_password_missing_uppercase_422(client):
+    r = client.post("/auth/register", json={"email": "noupper@example.com", "password": "password1!"})
+    assert r.status_code == 422
+
+
+def test_register_password_missing_lowercase_422(client):
+    r = client.post("/auth/register", json={"email": "nolower@example.com", "password": "PASSWORD1!"})
+    assert r.status_code == 422
+
+
+def test_register_password_missing_number_422(client):
+    r = client.post("/auth/register", json={"email": "nonumber@example.com", "password": "Password!!"})
+    assert r.status_code == 422
+
+
+def test_register_password_missing_special_char_422(client):
+    r = client.post("/auth/register", json={"email": "nospecial@example.com", "password": "Password12"})
+    assert r.status_code == 422

--- a/backend/tests/auth/test_security.py
+++ b/backend/tests/auth/test_security.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta, timezone
+from jose import jwt
+
+from app.core import security
+
+
+def test_me_valid_token_but_user_deleted_or_not_in_db(client):
+    """
+    SECURITY TEST:
+
+    This test checks something important about JWT authentication.
+
+    Even if a token is technically valid ,
+    that does NOT automatically mean the user is still valid in the system.
+
+    For example:
+    - A user logs in and gets a token.
+    - later, that user gets deleted from the database.
+    - the token itself is still valid until it expires (after 1 houre) .
+
+    so after decoding the token, the backend must still check
+    if the user actually exists in the database, if the user is not found, the system should return 401.
+    """
+
+    # create a token that is valid 
+    # BUT the email inside it does not exist in our db.
+    payload = {
+        "sub": "deleteduser@example.com",  # this user is NOT in db
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+    }
+
+    token = jwt.encode(payload, security.JWT_SECRET, algorithm=security.ALGORITHM)
+
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert "user not found" in response.json()["detail"].lower()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.database import Base, get_db
+
+# use a separate sqlite database for tests
+TEST_DATABASE_URL = "sqlite:///./test.db"
+
+engine = create_engine(
+    TEST_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+)
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    """
+    makes every test run with a new database.
+    it prevents tests from affecting each other
+    """
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)


### PR DESCRIPTION
In this PR, I added a structured test suite for the authentication system.

The tests cover:

- User registration (including validation rules and duplicate email handling)
- Login (success and failure cases)
- JWT token generation and verification
- Protected /auth/me endpoint
- A security test where a token is valid but the user no longer exists
- Database isolation using conftest.py

The current test coverage is 93%.
<img width="799" height="345" alt="Screenshot 2026-03-01 at 8 47 32 PM" src="https://github.com/user-attachments/assets/6b33cff0-536f-4089-9b34-b79dd93f1295" />
